### PR TITLE
Refinement of sensor handling - Update_2019-11-18

### DIFF
--- a/Ds18b20.h
+++ b/Ds18b20.h
@@ -1,0 +1,195 @@
+//- -----------------------------------------------------------------------------------------------------------------------
+// AskSin++
+// 2018-04-03 papa Creative Commons           - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
+// 2019-11-18 Wolfram Winter Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
+//- -----------------------------------------------------------------------------------------------------------------------
+
+#ifndef __SENSORS_DS18B20_h__
+#define __SENSORS_DS18B20_h__
+
+#include <Sensors.h>
+#if defined(ARDUINO_ARCH_STM32F1)
+#include <OneWireSTM.h>
+#else
+#include <OneWire.h>
+#endif
+
+#define SENSORS_DS18B20_TEMP_ERROR  -999
+
+// https://www.tweaking4all.com/hardware/arduino/arduino-ds18b20-temperature-sensor/
+
+namespace as {
+
+class Ds18b20 : public Temperature {
+
+public:
+  /**
+   * Scan the bus and init max sensors with the address.
+   */
+  static uint8_t init (OneWire& ow, Ds18b20* devs, uint8_t max, String *arrDevsAddr = NULL) {
+    uint8_t a[8], num=0;
+    if (arrDevsAddr) {
+      for (uint8_t j = 0; j < max; j++) {
+        arrDevsAddr[j] = "";
+      }
+    }
+    while( ow.search(a) == 1 && num < max) {
+      if( OneWire::crc8(a,7) == a[7] ) {
+        if( Ds18b20::valid(a) == true ) {
+// #ifndef NDEBUG
+//           DPRINT("Init DS18x20 found ");
+//           DDEC(num+1);
+//           DPRINT(": ");
+//           for (uint8_t i = 0; i < 8; i++) {
+//             DHEX(a[i]);
+//           }
+//           DPRINTLN("");
+// #endif
+          if (arrDevsAddr) {
+            String str = "";
+            for (uint8_t i = 0; i < 8; i++) {
+              // Arduino HEX bug 
+              // https://github.com/arduino/ArduinoCore-API/issues/40
+              String tmp = String(a[i], HEX);
+              str += (tmp.length()<2) ? ("0" + tmp) : tmp;
+            }
+            str.toUpperCase();
+            *arrDevsAddr++ = str;
+          }
+          devs->init(ow,a);
+          ++num;
+          ++devs;
+        }
+      }
+    }
+    return num;
+  }
+  /**
+   * Measure all sensors in one step
+   */
+  static void measure (Ds18b20* devs,uint8_t count, String *arrDevsAddr = NULL) {
+    String str;
+    if (arrDevsAddr) {
+      for (uint8_t j = 0; j < count; j++) {
+        arrDevsAddr[j] = "";
+      }
+    }
+    if (count > 0) {
+      devs->convert(true); // this will trigger all DS18b20 on the bus
+      devs->wait(); // this will also wait for all to be finish
+      for( uint8_t num=0; num < count; ++num, ++devs ) {
+        devs->read(&str); // read value for every device
+        *arrDevsAddr++ = str;
+// #ifndef NDEBUG
+//         DPRINT("Measure DS18x20 ");
+//         DDEC(num+1);
+//         DPRINT(": " + str + "  Temp: ");
+//         DDECLN(devs->temperature());
+// #endif
+      }
+    }
+  }
+  /**
+   * Check if this is a supported 1Wire device
+   */
+  static bool valid(uint8_t* addr) {
+    return *addr == 0x10 || *addr == 0x28 || *addr == 0x22;
+  }
+
+private:
+  uint8_t  _addr[8];
+  OneWire* _wire;
+
+public:
+  Ds18b20 () : _wire(0) {}
+
+  void init (OneWire& ow,uint8_t* addr) {
+    _wire = &ow;
+    for( uint8_t i=0; i<8; ++i )
+      _addr[i]=addr[i];
+    _present = true;
+  }
+
+  void convert(__attribute__((unused)) bool kick=false) {
+    _wire->reset();
+    if( kick == true ) {
+      _wire->skip();
+    }
+    else {
+      _wire->select(_addr);
+    }
+    _wire->write(0x44);        // start conversion, use ds.write(0x44,1) with parasite power on at the end
+  }
+
+  void wait () {
+    //delay(750);
+    while (_wire->read() == 0) ;
+  }
+
+  void read (String *DevsAddr = NULL) {
+    _wire->reset();
+    _wire->select(_addr);
+    _wire->write(0xBE);         // Read Scratchpad
+
+    _temperature = SENSORS_DS18B20_TEMP_ERROR;
+
+    uint8_t data[9];
+    for (uint8_t i = 0; i < 9; i++) { // we need 9 bytes
+      data[i] = _wire->read();
+    }
+    if (OneWire::crc8(data, 8) == data[8]) {
+      int16_t raw = (data[1] << 8) | data[0];
+// #ifndef NDEBUG
+//      DPRINT("Read DS18x20: ");
+//      for (uint8_t i = 0; i < 8; i++) {
+//        DHEX(_addr[i]);
+//      }
+// #endif    
+      if (_addr[0] != 0x0) {
+        if (_addr[0] == 0x10) {
+          raw = raw << 3; // 9 bit resolution default
+          if (data[7] == 0x10) {
+            // "count remain" gives full 12 bit resolution
+            raw = (raw & 0xFFF0) + 12 - data[6];
+          }
+        } else {
+          byte cfg = (data[4] & 0x60);
+          // at lower res, the low bits are undefined, so let's zero them
+          if (cfg == 0x00) raw = raw & ~7;  // 9 bit resolution, 93.75 ms
+          else if (cfg == 0x20) raw = raw & ~3; // 10 bit res, 187.5 ms
+          else if (cfg == 0x40) raw = raw & ~1; // 11 bit res, 375 ms
+          //// default is 12 bit resolution, 750 ms conversion time
+        }
+        _temperature = (raw*10)/16;
+        _wire->depower();
+      }
+// #ifndef NDEBUG
+//      DPRINT(" Temp: ");
+//      DDECLN(_temperature);
+// #endif
+	  }
+    if (DevsAddr) {
+      *DevsAddr = "";
+      for (uint8_t i = 0; i < 8; i++) {
+        // Arduino HEX bug 
+        // https://github.com/arduino/ArduinoCore-API/issues/40
+        String tmp = String(_addr[i], HEX);
+        *DevsAddr += (tmp.length()<2) ? ("0" + tmp) : tmp;
+      }
+      DevsAddr->toUpperCase();
+    }
+  }
+
+  void measure (__attribute__((unused)) bool async=false) {
+    if( _present == true ) {
+      convert();
+      wait();
+      read();
+    }
+  }
+
+};
+
+}
+
+#endif

--- a/HB-UNI-Sen-TEMP-DS18B20.h
+++ b/HB-UNI-Sen-TEMP-DS18B20.h
@@ -1,0 +1,95 @@
+//---------------------------------------------------------
+// HB-UNI-Sens-TEMP-DS18B20.h
+//---------------------------------------------------------
+// 2016-10-31 papa Creative Commons
+// 2018-03-24 jp112sdl Creative Commons
+// 2019-11-19 Wolfram Winter Creative Commons
+// http://creativecommons.org/licenses/by-nc-sa/3.0/de/
+// You are free to Share & Adapt under the following terms:
+// Give Credit, NonCommercial, ShareAlike
+//---------------------------------------------------------
+
+#ifndef _HB-UNI-Sen-TEMP-DS18B20_H_
+#define _HB-UNI-Sen-TEMP-DS18B20_H_
+
+//---------------------------------------------------------
+// !! NDEBUG should be defined when the development and testing is done
+//
+// #define NDEBUG
+
+//---------------------------------------------------------
+// Device Angaben
+#define cDEVICE_ID      { 0xF3, 0x01, 0x01 }
+#define cDEVICE_SERIAL  "UNITEMP8-1"
+
+// Device Model  HB-UNI-Sen-TEMP-DS18B20
+// 1..8fach DS18B20 Temperatursensor
+// https://github.com/jp112sdl/JP-HB-Devices-addon
+#define cDEVICE_MODEL   {0xF3, 0x01}    
+
+//---------------------------------------------------------
+// Batterie-Limit [V*10]
+#define cBAT_LOW_LIMIT  22
+#define cBAT_CRT_LIMIT  18
+
+//---------------------------------------------------------
+// Sende-Intervall [sec]
+#define cSEND_INTERVAL  180      // 180 = 3 Minuten
+
+// not defined (default) - es wird immer der zuletzt gesetzte Sende-Intervallwert benutzt
+// defined               - cSEND_INTERVAL wird immer bei Modulstart neu gesetzt
+// #define cSEND_INTERVAL_ONSTART
+
+//---------------------------------------------------------
+// Pin-Anschluss der DS18B20 Sensoren
+#define cPORT_ONEWIRE   A5
+
+//---------------------------------------------------------
+// Anzahl der angeschlossenen Sensoren
+// und
+// Reihenfolge der Ausgabe der Sensor-Temperatur-Werte
+//---------------------------------------------------------
+//
+// defined 'cSENS_ID_ORDER'
+// ------------------------
+// - mit der Übergabe der vorher ermittelten Sensor-IDs (siehe unten) kann die 
+//   Reihenfolge bzw. die Zuordnung der Temperatur-Ausgabe auf die 8 Ports 
+//   festgelegt werden
+//   - es werden die Temperaturen in der vorgegebenen Reihenfolge ausgegeben
+//   - fällt ein Sensor aus (oder ist nicht vorhanden), dann wird -999 als 
+//     Temperatur ausgegeben
+//
+// not defined 'cSENS_ID_ORDER'
+// ----------------------------
+// - die Reihenfolge bzw. die Zuordnung der Temperatur-Ausgabe auf die 8 Ports 
+//   wird durch die Reihenfolge bei der Initialisierung der Sensoren festgelegt
+//   - es werden die (ansprechbaren) Sensoren nacheinander abgefragt
+//   - in der Regel findet die Ausgabe der Temperatur absteigend nach Sensor-ID
+//     statt (i.d.R.: Sensor mit höchster ID zuerst)
+//   - dabei werden evtl. defekte Sensoren übersprungen - dadurch kann die 
+//     Reihung der Temperatur-Ausgabe durcheinander kommen
+//   - es findet keine Fehlerabfrage statt
+// - mit dieser Einstellung können im Debug-Modus die Sensor-IDs ermittelten
+//   werden (siehe oben)
+// - siehe auch: https://homematic-forum.de/forum/viewtopic.php?t=45004#p451960
+// 
+
+// Anzahl der abzufragenden DS18B20 Sensoren (max. 8)
+#define cANZ_SENSORS    2
+
+// Flag für die Vorgabe / Sortierung der DS18B20 Temperaturwerte
+// auskommentieren, wenn keine Sortierung
+#define cSENS_ID_ORDER
+
+// Vorgabe / Sortierung der DS18B20 Sensoren
+//  !!! cSENS_ID_x  mit 0 oder 16 Zeichen !!!
+#define cSENS_ID_1      "28AA9933191302C8"
+#define cSENS_ID_2      "28AA9CFF1813029A"
+#define cSENS_ID_3      ""
+#define cSENS_ID_4      ""
+#define cSENS_ID_5      ""
+#define cSENS_ID_6      ""
+#define cSENS_ID_7      ""
+#define cSENS_ID_8      ""
+
+#endif


### PR DESCRIPTION
Hallo Jerome,
hier der PR ... wie im HM-Forum beschrieben:
https://homematic-forum.de/forum/viewtopic.php?f=76&t=42651&start=240#p543517

Besteht aus drei Dateien:
- Ds18b20.h 
Erweiterung: 'init', 'measure' und 'read' Funktionen mit optionalen Aufrufparameter für String-Rückgabe der Sensor-IDs. Wird momentan lokal eingebunden - wäre möglich ohne Änderung in die Asksinn-Lib zu übernehmen, dann globale Einbindung (-> Entfall hier ...).

- HB-UNI-Sen-TEMP-DS18B20.h
Zusammenfassung aller (möglichen) Konfigurationsparameter (ausserhalb des INO-Files)

- HB-UNI-Sen-TEMP-DS18B20.ino
Geänderte INO-Datei. Es ist jetzt möglich, bestimmte Sensoren auf bestimmte Ports zu  legen - dazu wird die ID des jeweiligen Sensor benutzt (#define cSENS_ID_ORDER in 'HB-UNI-Sen-TEMP-DS18B20.h'). Beispiel: man kann das Modul mit 4 Ports konfigurieren (#define cANZ_SENSORS 4 in 'HB-UNI-Sen-TEMP-DS18B20.h'), bei dem man aber nur für die Ports 3 und 4 die IDs einträgt, weil man erst später die Ports 1 und 2 mit Sensoren bestücken möchte. Angezeigt werden dann die Ports 1 ... 4, wobei die Ports 1 und 2 den Fehlerwert -999 liefern (Sensorfehler).
Wird das #define cSENS_ID_ORDER in 'HB-UNI-Sen-TEMP-DS18B20.h' auskommentiert, verhält sich das Modul wie vorher: es werden alle IDs der angeschlossenen Sensoren in der Busreihenfolge ermittelt und dann auch in dieser Reihenfolge ausgegeben.

Der Quelltextverlauf wurde insgesamt beibehalten und nur um die drei ID-Arrays erweitert. 
Mir ist immer wichtig, die Originalmessung (oder den entsprechenden Fehlerwert) zu erhalten - ich persönlich halte NICHTS von 'Berechnungen' o.ä. Dingen während der Erfassung - dies ist IMMER Gegenstand ider Auswertung.
Gruß
Wolfram